### PR TITLE
removed outdated PySCF version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-BASE_DEPENDENCIES = ["numpy", "jax", "pyscf<=2.3.0"]
+BASE_DEPENDENCIES = ["numpy", "jax", "pyscf"]
 
 setup(
     name="autoxc",


### PR DESCRIPTION
Simply removed requirement for PySCF version 2.3.0 or earlier, as it became inconvenient to have to reinstall newest version of PySCF upon its uninstallation being invoked by auto-xc.

Solves issue #2 